### PR TITLE
lock Flask-SQLAlchemy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask
 Flask-Alchy
 Flask-Bootstrap
+Flask-SQLAlchemy==2.1
 PyYAML
 SQLAlchemy
 alchy


### PR DESCRIPTION
How to test:
1. Install on stage

Expected outcome:
`Successfully installed ... Flask-SQLAlchemy-2.1 ...`