### PR TITLE
Iseq parse fix

### DIFF
--- a/cgstats/db/iseqparse.py
+++ b/cgstats/db/iseqparse.py
@@ -6,6 +6,7 @@ import errno
 import logging
 import os
 import os.path
+from pathlib import Path
 import socket
 import sys
 from glob import glob

--- a/cgstats/db/iseqparse.py
+++ b/cgstats/db/iseqparse.py
@@ -300,7 +300,3 @@ def add(manager, demux_dir, unaligned_dir):
     manager.commit()
 
     return True
-
-
-if __name__ == '__main__':
-    xadd(sys.argv[1:])

--- a/cgstats/db/iseqparse.py
+++ b/cgstats/db/iseqparse.py
@@ -48,7 +48,7 @@ def gather_supportparams(demux_dir, unaligned_dir):
     # get some info from bcl2 fastq
     demux_dir = Path(demux_dir)
     logfile = demux_dir.joinpath('projectlog.*.log')
-    logfilenames = glob(logfile)  # should yield one result
+    logfilenames = glob(str(logfile))  # should yield one result
     logfilenames.sort(key=os.path.getmtime, reverse=True)
     if len(logfilenames) == 0:
         LOGGER.error('No log files found! Looking for %s', format(logfile))
@@ -89,7 +89,7 @@ def gather_datasource(run_dir, unaligned_dir):
     datasource = {}  # result set
 
     # get the run name
-    datasource['runname'] = str(run_dir.normpath().basename())
+    datasource['runname'] = str(run_dir.resolve().stem)
 
     # get the run date
     datasource['rundate'] = datasource['runname'].split('_')[0]
@@ -119,7 +119,7 @@ def gather_demux(run_dir):
     # get some info from bcl2 fastq
     run_dir = Path(run_dir)
     logfile = run_dir.joinpath('projectlog.*.log')
-    logfilenames = glob(logfile)  # should yield one result
+    logfilenames = glob(str(logfile))  # should yield one result
     logfilenames.sort(key=os.path.getmtime, reverse=True)
     if len(logfilenames) == 0:
         LOGGER.error('No log files found! Looking for %s', format(logfile))

--- a/cgstats/utils/iseqstats.py
+++ b/cgstats/utils/iseqstats.py
@@ -6,6 +6,7 @@ import glob
 import logging
 import os
 import os.path
+from pathlib import Path
 import re
 import xml.etree.cElementTree as et
 


### PR DESCRIPTION
Fix iseq parse defects

How to install:
`ssh thalamus` as hiseq.clinical
`source activate stage`
`pip install -U git+https://github.com/Clinical-Genomics/cgstats.git@iseq-parse-fix`


How to test:

cgstats add --machine iseq --unaligned Unaligned-Y30I10I10 /home/hiseq.clinical/iseq/demux//20190528_FS10000534_7_BPC29611-3324
Expected outcome:

 new entry in database
- [ ] flowcell name is BPC29611-3324
- [ ] pos is 'A'
- [ ] hiseqtype is 'iseq'

This is a patch: it's a bugfix

- [x] R @ingkebil 
- [x] T @barrystokman @patrikgrenfeldt 
- [x] D @patrikgrenfeldt 