### PR TITLE
2500 demux on hasta

### DIFF
--- a/cgstats/constants/__init__.py
+++ b/cgstats/constants/__init__.py
@@ -1,0 +1,3 @@
+""" Gather all constants here """
+
+from .constants import SEQUENCERS

--- a/cgstats/constants/constants.py
+++ b/cgstats/constants/constants.py
@@ -1,0 +1,6 @@
+""" Constants for cgstats """
+
+SEQUENCERS = {
+    "novaseq": "novaseq",
+    "2500": "hiseqga",
+}

--- a/cgstats/db/cli.py
+++ b/cgstats/db/cli.py
@@ -144,17 +144,8 @@ def add(context, machine, demux_dir, unaligned, all_unaligned):
 
     if machine == 'X':
         xparse.add(manager, demux_dir)
-    # if machine == '2500':
-    #     if all_unaligned:
-    #         unaligned_dirs = glob(Path(demux_dir).joinpath('Unaligned*'))
-    #         for unaligned in unaligned_dirs:
-    #             log.info('Adding {}.'.format(unaligned))
-    #             parse.add(manager, demux_dir, unaligned)
-    #     else:
-    #         log.info('Adding {}.'.format(unaligned))
-    #         parse.add(manager, demux_dir, unaligned)
     if machine == 'novaseq' or machine == '2500':
-        if not unaligned:
+        if not unaligned and machine == 'novaseq':
             click.echo(click.style("Please specify an unaligned directory for NovaSeq!", fg='yellow'))
             context.abort()
         if all_unaligned:
@@ -163,6 +154,7 @@ def add(context, machine, demux_dir, unaligned, all_unaligned):
                 log.info('Adding {}.'.format(unaligned))
                 novaseqparse.add(manager, demux_dir, unaligned, machine)
         else:
+            log.info('Adding {}.'.format(unaligned))
             novaseqparse.add(manager, demux_dir, unaligned, machine)
     if machine == 'iseq':
         if not unaligned:

--- a/cgstats/db/cli.py
+++ b/cgstats/db/cli.py
@@ -161,9 +161,9 @@ def add(context, machine, demux_dir, unaligned, all_unaligned):
             unaligned_dirs = glob(Path(demux_dir).joinpath('Unaligned*'))
             for unaligned in unaligned_dirs:
                 log.info('Adding {}.'.format(unaligned))
-                novaseqparse.add(manager, demux_dir, unaligned)
+                novaseqparse.add(manager, demux_dir, unaligned, machine)
         else:
-            novaseqparse.add(manager, demux_dir, unaligned)
+            novaseqparse.add(manager, demux_dir, unaligned, machine)
     if machine == 'iseq':
         if not unaligned:
             click.echo(click.style("Please specify an unaligned directory for iSeq!", fg='yellow'))

--- a/cgstats/db/cli.py
+++ b/cgstats/db/cli.py
@@ -144,16 +144,16 @@ def add(context, machine, demux_dir, unaligned, all_unaligned):
 
     if machine == 'X':
         xparse.add(manager, demux_dir)
-    if machine == '2500':
-        if all_unaligned:
-            unaligned_dirs = glob(Path(demux_dir).joinpath('Unaligned*'))
-            for unaligned in unaligned_dirs:
-                log.info('Adding {}.'.format(unaligned))
-                parse.add(manager, demux_dir, unaligned)
-        else:
-            log.info('Adding {}.'.format(unaligned))
-            parse.add(manager, demux_dir, unaligned)
-    if machine == 'novaseq':
+    # if machine == '2500':
+    #     if all_unaligned:
+    #         unaligned_dirs = glob(Path(demux_dir).joinpath('Unaligned*'))
+    #         for unaligned in unaligned_dirs:
+    #             log.info('Adding {}.'.format(unaligned))
+    #             parse.add(manager, demux_dir, unaligned)
+    #     else:
+    #         log.info('Adding {}.'.format(unaligned))
+    #         parse.add(manager, demux_dir, unaligned)
+    if machine == 'novaseq' or machine == '2500':
         if not unaligned:
             click.echo(click.style("Please specify an unaligned directory for NovaSeq!", fg='yellow'))
             context.abort()

--- a/cgstats/db/novaseqparse.py
+++ b/cgstats/db/novaseqparse.py
@@ -2,19 +2,20 @@
 # encoding: utf-8
 
 from __future__ import print_function, division
-import sys
-import os
 from glob import glob
 import logging
+import os
 import socket
+import sys
 
 from path import Path
 from sqlalchemy import func
 
-from demux.utils import Samplesheet
+from cgstats.constants import SEQUENCERS
 from cgstats.db.models import Supportparams, Version, Datasource, Flowcell, Demux, Project, Sample, Unaligned
 from cgstats.utils import novaseqstats
 from cgstats.utils.utils import get_projects, gather_flowcell
+from demux.utils import Samplesheet
 
 logger = logging.getLogger(__name__)
 
@@ -251,7 +252,7 @@ def add(manager, demux_dir, unaligned_dir, machine):
         flowcell = Flowcell()
         flowcell.flowcellname = flowcell_name
         flowcell.flowcell_pos = flowcell_pos
-        flowcell.hiseqtype = machine
+        flowcell.hiseqtype = SEQUENCERS[machine]
         flowcell.time = func.now()
 
         manager.add(flowcell)

--- a/cgstats/db/novaseqparse.py
+++ b/cgstats/db/novaseqparse.py
@@ -201,7 +201,7 @@ def get_nr_samples_lane(sample_sheet):
     return samples_lane
 
 
-def add(manager, demux_dir, unaligned_dir):
+def add(manager, demux_dir, unaligned_dir, machine):
     """ Gathers and adds all data to cgstats.
 
     params:
@@ -251,7 +251,7 @@ def add(manager, demux_dir, unaligned_dir):
         flowcell = Flowcell()
         flowcell.flowcellname = flowcell_name
         flowcell.flowcell_pos = flowcell_pos
-        flowcell.hiseqtype = 'novaseq'
+        flowcell.hiseqtype = machine
         flowcell.time = func.now()
 
         manager.add(flowcell)


### PR DESCRIPTION
### This PR fixes stats parsing for 2500 demux runs. 2500 demultiplexing is migrated to hasta where demutliplexing runs a newer version of bcl2fastq (v2.20) and these changes enable correct stats parsing. 

**How to prepare for test**:
See https://github.com/Clinical-Genomics/demultiplexing/pull/144

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MINOR** - when you add functionality in a backwards compatible manner

To be deployed on Hasta with https://github.com/Clinical-Genomics/demultiplexing/pull/144 and https://github.com/Clinical-Genomics/servers/pull/498. Note that deploying https://github.com/Clinical-Genomics/demultiplexing/pull/144 will automatically deploy the latest version of `cgstats` so merge this PR before deploying the `demultiplexing` PR 